### PR TITLE
Repress errors in Issue #3

### DIFF
--- a/jquery.pulse.js
+++ b/jquery.pulse.js
@@ -44,6 +44,7 @@
       var timesPulsed = 0;
 
       function animate() {
+        if (typeof el.data('pulse') === 'undefined') return;
         if (el.data('pulse').stop) return;
         if (options.pulses > -1 && ++timesPulsed > options.pulses) return callback.apply(el);
         el.animate(


### PR DESCRIPTION
Repress errors if the element the pulse is attached to is removed before the animation has time to finish.
